### PR TITLE
Implement tmp::file::write and tmp::file::append

### DIFF
--- a/include/tmp/file.hpp
+++ b/include/tmp/file.hpp
@@ -94,11 +94,6 @@ public:
         return std::addressof(this->p);
     }
 
-    /// Inserts @p content into this file
-    void operator<<(std::string_view content) const {
-        std::ofstream { this->path(), std::ios::binary } << content;
-    }
-
     /// Deletes this file when the enclosing scope is exited
     ~file() noexcept { this->remove(); }
 

--- a/include/tmp/file.hpp
+++ b/include/tmp/file.hpp
@@ -19,8 +19,8 @@ namespace tmp {
 /// <system's default location for temporary files>/prefix/. The prefix can be
 /// a path consisting of multiple segments.
 ///
-/// The tmp::file class also provides an additional operator<< which allows
-/// writing data to the temporary file using the same syntax as std::cout.
+/// The tmp::file class also provides an additional write and append methods
+/// which allow writing data to the temporary file.
 ///
 /// When the object is destroyed, it deletes the temporary file.
 ///
@@ -92,6 +92,16 @@ public:
     /// Provides access to this file path members
     const std::filesystem::path* operator->() const noexcept {
         return std::addressof(this->p);
+    }
+
+    /// Writes the given @p content to this file discarding any previous content
+    void write(std::string_view content, std::ios_base::openmode mode = 0) {
+        std::ofstream { this->path(), std::ios_base::trunc | mode } << content;
+    }
+
+    /// Appends the given @p content to the end of this file
+    void append(std::string_view content, std::ios_base::openmode mode = 0) {
+        std::ofstream { this->path(), std::ios_base::app | mode } << content;
     }
 
     /// Deletes this file when the enclosing scope is exited

--- a/include/tmp/file.hpp
+++ b/include/tmp/file.hpp
@@ -48,7 +48,7 @@ namespace tmp {
 class file {
 public:
     /// Write mode for the temporary file
-    enum class write_mode : std::uint8_t {
+    enum class mode : std::uint8_t {
         text,      ///< Text mode
         binary,    ///< Binary mode
     };
@@ -57,7 +57,7 @@ public:
     /// for temporary files. If a prefix is provided to the constructor, the
     /// directory is created in the path <temp dir>/prefix/. The prefix can be
     /// a path consisting of multiple segments.
-    explicit file(std::string_view prefix = "", write_mode mode = write_mode::text) : mode(mode) {
+    explicit file(std::string_view prefix = "", mode mode = mode::text) : mode(mode) {
         const auto parent = std::filesystem::temp_directory_path() / prefix;
         std::string arg = parent / "XXXXXX";
 
@@ -65,6 +65,9 @@ public:
         ::mkstemp(arg.data());
         this->p = arg;
     }
+
+    /// Creates a unique temporary file without prefixes
+    explicit file(mode mode) : file("", mode) {}
 
     /// Creates a file from a moved @p other
     file(file&& other) noexcept : p(std::move(other.p)) {
@@ -108,12 +111,12 @@ public:
 
 private:
     std::filesystem::path p;    ///< This file path
-    write_mode mode;            ///< This file write mode
+    mode mode;                  ///< This file write mode
 
     /// Returns a stream for this file
     std::ofstream stream(bool append) const noexcept {
         std::ios::openmode mode = append ? std::ios::app : std::ios::trunc;
-        return this->mode == write_mode::binary
+        return this->mode == mode::binary
             ? std::ofstream { this->path(), mode | std::ios::binary }
             : std::ofstream { this->path(), mode };
     }

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -62,11 +62,24 @@ TEST(FileTest, MoveAssignment) {
     ASSERT_TRUE(fs::exists(fst));
 }
 
-TEST(FileTest, Streaming) {
-    const auto tmpfile = file();
-    tmpfile << "Hi";
+TEST(FileTest, Write) {
+    auto tmpfile = file();
+    tmpfile.write("Hello");
 
-    std::string s;
-    std::fstream(tmpfile.path(), std::ios::in) >> s;
-    ASSERT_EQ(s, "Hi");
+    std::ifstream stream(tmpfile.path());
+    std::string content(std::istreambuf_iterator<char>(stream), {});
+    ASSERT_EQ(content, "Hello");
+}
+
+TEST(FileTest, Append) {
+    auto tmpfile = file();
+    tmpfile.write("Hello");
+
+    tmpfile.append(", world!");
+
+    std::cout << tmpfile.path() << std::endl;
+
+    std::ifstream stream(tmpfile.path());
+    std::string content(std::istreambuf_iterator<char>(stream), {});
+    ASSERT_EQ(content, "Hello, world!");
 }

--- a/tests/file_test.cpp
+++ b/tests/file_test.cpp
@@ -63,7 +63,7 @@ TEST(FileTest, MoveAssignment) {
 }
 
 TEST(FileTest, Write) {
-    auto tmpfile = file();
+    const auto tmpfile = file();
     tmpfile.write("Hello");
 
     std::ifstream stream(tmpfile.path());
@@ -72,7 +72,7 @@ TEST(FileTest, Write) {
 }
 
 TEST(FileTest, Append) {
-    auto tmpfile = file();
+    const auto tmpfile = file();
     tmpfile.write("Hello");
 
     tmpfile.append(", world!");


### PR DESCRIPTION
- Remove unintuitive `operator<<`
- Make text and binary files distinctive
- Add write and append methods

Closes #1