### PR TITLE
Implement error handling

### DIFF
--- a/include/tmp/directory.hpp
+++ b/include/tmp/directory.hpp
@@ -62,10 +62,7 @@ public:
 private:
     /// Creates a unique temporary directory based on the given @p prefix
     static std::filesystem::path create(std::string_view prefix) {
-        const auto parent = std::filesystem::temp_directory_path() / prefix;
-        std::filesystem::create_directories(parent);
-
-        auto pattern = std::string(parent / "XXXXXX");
+        auto pattern = std::string(make_parent(prefix) / "XXXXXX");
         if (mkdtemp(pattern.data()) == nullptr) {
             auto ec = std::error_code(errno, std::system_category());
             throw error("Cannot create temporary directory", ec);

--- a/include/tmp/directory.hpp
+++ b/include/tmp/directory.hpp
@@ -62,7 +62,7 @@ public:
 private:
     /// Creates a unique temporary directory based on the given @p prefix
     static std::filesystem::path create(std::string_view prefix) {
-        auto pattern = std::string(make_parent(prefix) / "XXXXXX");
+        auto pattern = make_pattern(prefix);
         if (mkdtemp(pattern.data()) == nullptr) {
             auto ec = std::error_code(errno, std::system_category());
             throw error("Cannot create temporary directory", ec);

--- a/include/tmp/directory.hpp
+++ b/include/tmp/directory.hpp
@@ -44,7 +44,7 @@ public:
     /// for temporary files. If a prefix is provided to the constructor, the
     /// directory is created in the path <temp dir>/prefix/. The prefix can be
     /// a path consisting of multiple segments.
-    explicit directory(std::string_view prefix = "") : path(prefix, mkdtemp) {}
+    explicit directory(std::string_view prefix = "") : path(prefix, creator) {}
 
     /// Concatenates this directory path with a given @p source
     std::filesystem::path operator/(std::string_view source) const {
@@ -58,6 +58,18 @@ public:
     directory& operator=(directory&&) noexcept = default;    ///< move-assignable
     directory(const directory&) = delete;                    ///< not copy-constructible
     auto operator=(const directory&) = delete;               ///< not copy-assignable
+
+private:
+    /// Creates a unique temporary directory based on the given @p pattern path.
+    /// The parent path of the given argument must exist.
+    static std::string creator(std::string pattern) {
+        if (mkdtemp(pattern.data()) == nullptr) {
+            auto ec = std::error_code(errno, std::system_category());
+            throw error("Cannot create temporary directory", ec);
+        }
+
+        return pattern;
+    }
 };
 
 }    // namespace tmp

--- a/include/tmp/file.hpp
+++ b/include/tmp/file.hpp
@@ -91,7 +91,7 @@ private:
 
     /// Creates a unique temporary file based on the given @p prefix
     static std::filesystem::path create(std::string_view prefix) {
-        auto pattern = std::string(make_parent(prefix) / "XXXXXX");
+        auto pattern = make_pattern(prefix);
         if (mkstemp(pattern.data()) == -1) {
             auto ec = std::error_code(errno, std::system_category());
             throw error("Cannot create temporary file", ec);

--- a/include/tmp/file.hpp
+++ b/include/tmp/file.hpp
@@ -91,10 +91,7 @@ private:
 
     /// Creates a unique temporary file based on the given @p prefix
     static std::filesystem::path create(std::string_view prefix) {
-        const auto parent = std::filesystem::temp_directory_path() / prefix;
-        std::filesystem::create_directories(parent);
-
-        auto pattern = std::string(parent / "XXXXXX");
+        auto pattern = std::string(make_parent(prefix) / "XXXXXX");
         if (mkstemp(pattern.data()) == -1) {
             auto ec = std::error_code(errno, std::system_category());
             throw error("Cannot create temporary file", ec);

--- a/include/tmp/file.hpp
+++ b/include/tmp/file.hpp
@@ -86,8 +86,19 @@ private:
     /// for temporary files. If a prefix is provided to the constructor, the
     /// directory is created in the path <temp dir>/prefix/. The prefix can be
     /// a path consisting of multiple segments.
-    explicit file(std::string_view prefix, bool binary) : path(prefix, mkstemp),
+    explicit file(std::string_view prefix, bool binary) : path(prefix, creator),
                                                           binary(binary) {}
+
+    /// Creates a unique temporary file based on the given @p pattern path.
+    /// The parent path of the given argument must exist.
+    static std::string creator(std::string path) {
+        if (mkstemp(path.data()) == -1) {
+            auto ec = std::error_code(errno, std::system_category());
+            throw error("Cannot create temporary file", ec);
+        }
+
+        return path;
+    }
 
     /// Returns a stream for this file
     std::ofstream stream(bool append) const noexcept {

--- a/include/tmp/path.hpp
+++ b/include/tmp/path.hpp
@@ -52,7 +52,14 @@ protected:
     /// Creates a unique temporary path using the given constructor function.
     /// @param prefix the path between system temp
     /// @param creator wrapped mktemp-like function that returns resulting path
-    explicit path(std::filesystem::path path) : underlying(path){}
+    explicit path(std::filesystem::path path) : underlying(path) {}
+
+    static std::filesystem::path make_parent(std::string_view prefix) {
+        const auto parent = std::filesystem::temp_directory_path() / prefix;
+        std::filesystem::create_directories(parent);
+
+        return parent;
+    }
 
 private:
     /// Deletes this path recursively, ignoring any errors

--- a/include/tmp/path.hpp
+++ b/include/tmp/path.hpp
@@ -54,11 +54,11 @@ protected:
     /// @param creator wrapped mktemp-like function that returns resulting path
     explicit path(std::filesystem::path path) : underlying(std::move(path)) {}
 
-    static std::filesystem::path make_parent(std::string_view prefix) {
+    static std::string make_pattern(std::string_view prefix) {
         const auto parent = std::filesystem::temp_directory_path() / prefix;
         std::filesystem::create_directories(parent);
 
-        return parent;
+        return parent / "XXXXXX";
     }
 
 private:

--- a/include/tmp/path.hpp
+++ b/include/tmp/path.hpp
@@ -52,7 +52,7 @@ protected:
     /// Creates a unique temporary path using the given constructor function.
     /// @param prefix the path between system temp
     /// @param creator wrapped mktemp-like function that returns resulting path
-    explicit path(std::filesystem::path path) : underlying(path) {}
+    explicit path(std::filesystem::path path) : underlying(std::move(path)) {}
 
     static std::filesystem::path make_parent(std::string_view prefix) {
         const auto parent = std::filesystem::temp_directory_path() / prefix;

--- a/include/tmp/path.hpp
+++ b/include/tmp/path.hpp
@@ -54,6 +54,8 @@ protected:
     /// @param creator wrapped mktemp-like function that returns resulting path
     explicit path(std::filesystem::path path) : underlying(std::move(path)) {}
 
+    /// Creates a pattern for the mktemp-like functions.
+    /// If @p prefix is not empty, it is appended to the tempdir
     static std::string make_pattern(std::string_view prefix) {
         const auto parent = std::filesystem::temp_directory_path() / prefix;
         std::filesystem::create_directories(parent);

--- a/include/tmp/path.hpp
+++ b/include/tmp/path.hpp
@@ -52,12 +52,7 @@ protected:
     /// Creates a unique temporary path using the given constructor function.
     /// @param prefix the path between system temp
     /// @param creator wrapped mktemp-like function that returns resulting path
-    explicit path(std::string_view prefix, std::string(*creator)(std::string)) {
-        const auto parent = std::filesystem::temp_directory_path() / prefix;
-        std::filesystem::create_directories(parent);
-
-        this->underlying = creator(parent / "XXXXXX");
-    }
+    explicit path(std::filesystem::path path) : underlying(path){}
 
 private:
     /// Deletes this path recursively, ignoring any errors

--- a/include/tmp/path.hpp
+++ b/include/tmp/path.hpp
@@ -44,18 +44,19 @@ public:
     }
 
 protected:
+    /// Exception type that should be used by subclasses to signal errors
+    using error = std::filesystem::filesystem_error;
+
     std::filesystem::path underlying;    ///< This file path
 
-    /// Creates a unique temporary path using the given constructor function
-    template<typename C>
-    explicit path(std::string_view prefix, C constructor) {
+    /// Creates a unique temporary path using the given constructor function.
+    /// @param prefix the path between system temp
+    /// @param creator wrapped mktemp-like function that returns resulting path
+    explicit path(std::string_view prefix, std::string(*creator)(std::string)) {
         const auto parent = std::filesystem::temp_directory_path() / prefix;
         std::filesystem::create_directories(parent);
 
-        std::string arg = parent / "XXXXXX";
-        constructor(arg.data());
-
-        this->underlying = std::move(arg);
+        this->underlying = creator(parent / "XXXXXX");
     }
 
 private:


### PR DESCRIPTION
- tmp::path constructor accepts an already created temp path
- tmp::file and tmp::directory create temp paths by themselves

Closes #7 